### PR TITLE
Fix: Resolve build errors and refactor Genkit integration for Vercel

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,10 +3,10 @@ import type {NextConfig} from 'next';
 const nextConfig: NextConfig = {
   /* config options here */
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   eslint: {
-    ignoreDuringBuilds: true,
+    ignoreDuringBuilds: false,
   },
   images: {
     remotePatterns: [

--- a/src/ai/flows/extract-formulas-from-document.ts
+++ b/src/ai/flows/extract-formulas-from-document.ts
@@ -40,7 +40,7 @@ const extractFormulasFromDocumentPrompt = ai.definePrompt({
   Document: {{media url=documentDataUri}}`,
 });
 
-const extractFormulasFromDocumentFlow = ai.defineFlow(
+export const extractFormulasFromDocumentFlow = ai.defineFlow(
   {
     name: 'extractFormulasFromDocumentFlow',
     inputSchema: ExtractFormulasFromDocumentInputSchema,

--- a/src/ai/flows/extract-tables-from-document.ts
+++ b/src/ai/flows/extract-tables-from-document.ts
@@ -45,7 +45,7 @@ const extractTablesPrompt = ai.definePrompt({
   Document: {{media url=documentDataUri}}`,
 });
 
-const extractTablesFromDocumentFlow = ai.defineFlow(
+export const extractTablesFromDocumentFlow = ai.defineFlow(
   {
     name: 'extractTablesFromDocumentFlow',
     inputSchema: ExtractTablesFromDocumentInputSchema,

--- a/src/ai/flows/extract-text-from-document.ts
+++ b/src/ai/flows/extract-text-from-document.ts
@@ -38,7 +38,7 @@ const extractTextPrompt = ai.definePrompt({
 Document: {{media url=documentDataUri}}`,
 });
 
-const extractTextFromDocumentFlow = ai.defineFlow(
+export const extractTextFromDocumentFlow = ai.defineFlow(
   {
     name: 'extractTextFromDocumentFlow',
     inputSchema: ExtractTextFromDocumentInputSchema,

--- a/src/ai/flows/qa-on-document.ts
+++ b/src/ai/flows/qa-on-document.ts
@@ -46,7 +46,7 @@ Your tone should always be helpful and polite.
 User's Question: {{{question}}}`,
 });
 
-const qaOnDocumentFlow = ai.defineFlow(
+export const qaOnDocumentFlow = ai.defineFlow(
   {
     name: 'qaOnDocumentFlow',
     inputSchema: QaOnDocumentInputSchema,

--- a/src/app/api/extractFormulas/route.ts
+++ b/src/app/api/extractFormulas/route.ts
@@ -1,0 +1,5 @@
+// src/app/api/extractFormulas/route.ts
+import { appRoute } from '@genkit-ai/next';
+import { extractFormulasFromDocumentFlow } from '@/ai/flows/extract-formulas-from-document';
+
+export const POST = appRoute(extractFormulasFromDocumentFlow);

--- a/src/app/api/extractTables/route.ts
+++ b/src/app/api/extractTables/route.ts
@@ -1,0 +1,5 @@
+// src/app/api/extractTables/route.ts
+import { appRoute } from '@genkit-ai/next';
+import { extractTablesFromDocumentFlow } from '@/ai/flows/extract-tables-from-document';
+
+export const POST = appRoute(extractTablesFromDocumentFlow);

--- a/src/app/api/extractText/route.ts
+++ b/src/app/api/extractText/route.ts
@@ -1,0 +1,5 @@
+// src/app/api/extractText/route.ts
+import { appRoute } from '@genkit-ai/next';
+import { extractTextFromDocumentFlow } from '@/ai/flows/extract-text-from-document';
+
+export const POST = appRoute(extractTextFromDocumentFlow);

--- a/src/app/api/genkit/[[...path]]/route.ts
+++ b/src/app/api/genkit/[[...path]]/route.ts
@@ -1,8 +1,0 @@
-// src/app/api/genkit/[[...path]]/route.ts
-import { createNextApiHandler } from '@genkit-ai/next';
-import '@/ai/flows/extract-formulas-from-document';
-import '@/ai/flows/extract-tables-from-document';
-import '@/ai/flows/extract-text-from-document';
-import '@/ai/flows/qa-on-document';
-
-export const { GET, POST } = createNextApiHandler();

--- a/src/app/api/qaOnDocument/route.ts
+++ b/src/app/api/qaOnDocument/route.ts
@@ -1,0 +1,5 @@
+// src/app/api/qaOnDocument/route.ts
+import { appRoute } from '@genkit-ai/next';
+import { qaOnDocumentFlow } from '@/ai/flows/qa-on-document';
+
+export const POST = appRoute(qaOnDocumentFlow);

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "framework": "nextjs"
+}


### PR DESCRIPTION
- Modified next.config.ts to surface build errors during debugging.
- Fixed type errors related to @genkit-ai/next by using the `appRoute` handler and adjusting import/export of Genkit flows.
- Refactored Genkit API routes from a single catch-all to individual routes per flow (e.g., /api/extractFormulas) as required by @genkit-ai/next@1.8.0.
- Added a minimal vercel.json.
- Ensured all Genkit flows are correctly exported and consumed by their respective API route handlers.

The application now builds successfully, and the API structure is suitable for deployment to Vercel.